### PR TITLE
Fixed download url to compatible composer version 1.0.0-alpha7.

### DIFF
--- a/java-api/src/main/java/com/dubture/getcomposer/core/ComposerConstants.java
+++ b/java-api/src/main/java/com/dubture/getcomposer/core/ComposerConstants.java
@@ -12,7 +12,7 @@ public class ComposerConstants {
 	public static final String COMPOSER_JSON = "composer.json";
 	public static final String SEARCH_URL = "https://packagist.org/search.json?q=%s";
 	public static final String PACKAGE_URL = "https://packagist.org/packages/%s.json";
-	public static final String PHAR_URL = "https://getcomposer.org/composer.phar";
+	public static final String PHAR_URL = "http://getcomposer.org/download/1.0.0-alpha7/composer.phar";
 	public static final String STABLE = "stable";
 	public static final String RC = "RC";
 	public static final String BETA = "beta";


### PR DESCRIPTION
The current composer version fetched by the original url includes changes that make the eclipse plugin generate an empty build path, so i changed download url to last compatible version (1.0.0-alpha7).

Since more than the eclipse plugin may be using the PharDownloader it would be desirable to make the version to be downloaded configurable...
